### PR TITLE
[wpmldev-6998] Add explicit nullable type hints in IndexHint and ParserException

### DIFF
--- a/src/Components/IndexHint.php
+++ b/src/Components/IndexHint.php
@@ -56,7 +56,7 @@ class IndexHint extends Component
      * @param string $for        the clause for which this hint is (JOIN/ORDER BY/GROUP BY)
      * @param string $indexes    List of indexes in this hint
      */
-    public function __construct(string $type = null, string $indexOrKey = null, string $for = null, array $indexes = array())
+    public function __construct(?string $type = null, ?string $indexOrKey = null, ?string $for = null, array $indexes = array())
     {
         $this->type = $type;
         $this->indexOrKey = $indexOrKey;

--- a/src/Exceptions/ParserException.php
+++ b/src/Exceptions/ParserException.php
@@ -31,7 +31,7 @@ class ParserException extends \Exception
      * @param Token  $token the token that produced this exception
      * @param int    $code  the code of this error
      */
-    public function __construct($msg = '', Token $token = null, $code = 0)
+    public function __construct($msg = '', ?Token $token = null, $code = 0)
     {
         parent::__construct($msg, $code);
         $this->token = $token;


### PR DESCRIPTION
Prevents PHP 8.4 "Implicitly marking parameter as nullable is deprecated" notices on:

- `IndexHint::__construct` — `$type`, `$indexOrKey`, `$for` (line 59)
- `ParserException::__construct` — `$token` (line 34)

Prefixing with `?` is byte-compatible with the implicit form and valid PHP 7.1+ (safe across PHP 7.4–8.5).

Verified locally via vendor patch under PHP 8.4.17 and 8.5.2: triggering `new PhpMyAdmin\SqlParser\Parser("SELECT * FROM t USE INDEX (idx)")` and `(new PhpMyAdmin\SqlParser\Parser("SELECT FROM WHERE"))->parse()` emits 0 implicit-nullable notices.

Part of [wpmldev-6998](https://onthegosystems.myjetbrains.com/youtrack/issue/wpmldev-6998) (sibling fixes in `wpml/wpml`, `wpml/fp`, `otgs/auryn`).